### PR TITLE
[pytest] section in setup.cfg is deprecated

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ tag_build = dev
 
 
 
-[pytest]
+[tool:pytest]
 addopts= --tb native -v -r fxX
 python_files=test/*test_*.py
 


### PR DESCRIPTION
Hello!

Trying to run the tests with Pytest 4.3.0 results in...

```
Failed: [pytest] section in setup.cfg files is no longer supported, change to [tool:pytest] instead.                                                                                                  
```

This PR heeds Pytests advice.