### PR TITLE
Document support for `with x as e:`

### DIFF
--- a/doc/build/syntax.rst
+++ b/doc/build/syntax.rst
@@ -84,8 +84,8 @@ using another ``%`` marker with the tag "``end<name>``", where
 The ``%`` can appear anywhere on the line as long as no text
 precedes it; indentation is not significant. The full range of
 Python "colon" expressions are allowed here, including
-``if``/``elif``/``else``, ``while``, ``for``, and even ``def``, although
-Mako has a built-in tag for defs which is more full-featured.
+``if``/``elif``/``else``, ``while``, ``for``, ``with``, and even ``def``,
+although Mako has a built-in tag for defs which is more full-featured.
 
 .. sourcecode:: mako
 


### PR DESCRIPTION
This has been supported since 8bebfc205230d41429a88c98b56d45acf7e67226 but isn't in the docs.