### PR TITLE
Use Constant.value, not Constant.n

### DIFF
--- a/mako/_ast_util.py
+++ b/mako/_ast_util.py
@@ -682,7 +682,7 @@ class SourceGenerator(NodeVisitor):
 
     # newly needed in Python 3.8
     def visit_Constant(self, node):
-        self.write(repr(node.n))
+        self.write(repr(node.value))
 
     def visit_Tuple(self, node):
         self.write('(')


### PR DESCRIPTION
Since Python 3.8, class ast.Constant is used for all constants.
Old classes ast.Num, ast.Str, ast.Bytes, ast.NameConstant and
ast.Ellipsis are still available, but they will be removed in
future Python releases.

Constants have values, but not always ns.

See https://github.com/sqlalchemy/mako/issues/287#issuecomment-482163543
See https://github.com/python/cpython/pull/9445
Fixes https://github.com/Pylons/pyramid_mako/issues/47