### PR TITLE
Correctly track line numbers for multi-line code blocks

### DIFF
--- a/mako/codegen.py
+++ b/mako/codegen.py
@@ -354,8 +354,7 @@ class _GenerateRenderMethod(object):
         """write module-level template code, i.e. that which
         is enclosed in <%! %> tags in the template."""
         for n in module_code:
-            self.printer.start_source(n.lineno)
-            self.printer.write_indented_block(n.text)
+            self.printer.write_indented_block(n.text, lineno=n.lineno)
 
     def write_inherit(self, node):
         """write the module-level inheritance-determination callable."""
@@ -896,8 +895,7 @@ class _GenerateRenderMethod(object):
 
     def visitCode(self, node):
         if not node.ismodule:
-            self.printer.start_source(node.lineno)
-            self.printer.write_indented_block(node.text)
+            self.printer.write_indented_block(node.text, lineno=node.lineno)
 
             if not self.in_def and len(self.identifiers.locally_assigned) > 0:
                 # if we are the "template" def, fudge locally

--- a/mako/pygen.py
+++ b/mako/pygen.py
@@ -54,14 +54,16 @@ class PythonPrinter(object):
         self.stream.write("\n" * num)
         self._update_lineno(num)
 
-    def write_indented_block(self, block):
+    def write_indented_block(self, block, lineno=None):
         """print a line or lines of python which already contain indentation.
 
         The indentation of the total block of lines will be adjusted to that of
         the current indent level."""
         self.in_indent_lines = False
-        for l in re.split(r"\r?\n", block):
+        for i, l in enumerate(re.split(r"\r?\n", block)):
             self.line_buffer.append(l)
+            if lineno is not None:
+                self.start_source(lineno + i)
             self._update_lineno(1)
 
     def writelines(self, *lines):

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -383,3 +383,51 @@ ${foobar}
             "local variable &#39;y&#39; referenced before assignment"
             in html_error
         )
+
+    def test_code_block_line_number(self):
+        l = TemplateLookup()
+        l.put_string(
+            "foo.html",
+            """
+<%
+msg = "Something went wrong."
+raise RuntimeError(msg)  # This is the line.
+%>
+            """,
+        )
+        t = l.get_template("foo.html")
+        try:
+            t.render()
+            assert False
+        except:
+            text_error = exceptions.text_error_template().render_unicode()
+            assert 'File "foo_html", line 4, in render_body' in text_error
+            assert "raise RuntimeError(msg)  # This is the line." in text_error
+        else:
+            assert False
+
+    def test_module_block_line_number(self):
+        l = TemplateLookup()
+        l.put_string(
+            "foo.html",
+            """
+<%!
+def foo():
+    msg = "Something went wrong."
+    raise RuntimeError(msg)  # This is the line.
+%>
+${foo()}
+            """,
+        )
+        t = l.get_template("foo.html")
+        try:
+            t.render()
+            assert False
+        except:
+            text_error = exceptions.text_error_template().render_unicode()
+            sys.stderr.write(text_error)
+            assert 'File "foo_html", line 7, in render_body' in text_error
+            assert 'File "foo_html", line 5, in foo' in text_error
+            assert "raise RuntimeError(msg)  # This is the line." in text_error
+        else:
+            assert False


### PR DESCRIPTION
Up till now, exceptions in `<% … %>` or `<%!  … %>` code blocks would have their errors reported in the opening line when formatting a stack trace.  With these changes, every line of a code block gets an entry in the line map, which allows attributing them correctly.

Exceptions in `<%! … %>` blocks which get raised while loading the module are still not reported correctly.  At that time, the metadata infrastructure for exception reporting does not exist yet, so the stack trace will reference to the raw generated code and not get rewritten.