### PR TITLE
Include URI in traceback if filename is unknown

### DIFF
--- a/mako/exceptions.py
+++ b/mako/exceptions.py
@@ -159,13 +159,17 @@ class RichTraceback(object):
             if not line:
                 line = ""
             try:
-                (line_map, template_lines) = mods[filename]
+                (line_map, template_lines, template_filename) = mods[filename]
             except KeyError:
                 try:
                     info = mako.template._get_module_info(filename)
                     module_source = info.code
                     template_source = info.source
-                    template_filename = info.template_filename or filename
+                    template_filename = (
+                        info.template_filename
+                        or info.template_uri
+                        or filename
+                    )
                 except KeyError:
                     # A normal .py file (not a Template)
                     if not compat.py3k:
@@ -204,7 +208,7 @@ class RichTraceback(object):
                 template_lines = [
                     line_ for line_ in template_source.split("\n")
                 ]
-                mods[filename] = (line_map, template_lines)
+                mods[filename] = (line_map, template_lines, template_filename)
 
             template_ln = line_map[lineno - 1]
 

--- a/mako/template.py
+++ b/mako/template.py
@@ -330,7 +330,7 @@ class Template(object):
             (code, module) = _compile_text(self, text, filename)
             self._code = code
             self._source = text
-            ModuleInfo(module, None, self, filename, code, text)
+            ModuleInfo(module, None, self, filename, code, text, uri)
         elif filename is not None:
             # if template filename and a module directory, load
             # a filesystem-based module file, generating if needed
@@ -421,7 +421,7 @@ class Template(object):
                 )
                 module = compat.load_module(self.module_id, path)
                 del sys.modules[self.module_id]
-            ModuleInfo(module, path, self, filename, None, None)
+            ModuleInfo(module, path, self, filename, None, None, None)
         else:
             # template filename and no module directory, compile code
             # in memory
@@ -429,7 +429,7 @@ class Template(object):
             code, module = _compile_text(self, data, filename)
             self._source = None
             self._code = code
-            ModuleInfo(module, None, self, filename, code, None)
+            ModuleInfo(module, None, self, filename, code, None, None)
         return module
 
     @property
@@ -584,6 +584,7 @@ class ModuleTemplate(Template):
             template_filename,
             module_source,
             template_source,
+            module._template_uri,
         )
 
         self.callable_ = self.module.render_body
@@ -641,12 +642,14 @@ class ModuleInfo(object):
         template_filename,
         module_source,
         template_source,
+        template_uri,
     ):
         self.module = module
         self.module_filename = module_filename
         self.template_filename = template_filename
         self.module_source = module_source
         self.template_source = template_source
+        self.template_uri = template_uri
         self._modules[module.__name__] = template._mmarker = self
         if module_filename:
             self._modules[module_filename] = self


### PR DESCRIPTION
Using URIs as entrered will make the stack trace arguably more readable than
using the module name which is the URI with non-word characters replaced by
underscores.

This change also fixes a mistake where a mods cache hit would not update
template_filename, causing a stale filename to be displayed if the stack
trace alternates between different templates.  There now is a test case for
this.