### PR TITLE
compat: use timeit.default_timer instead of time.clock which is gone in Python 3.8

### DIFF
--- a/mako/compat.py
+++ b/mako/compat.py
@@ -6,7 +6,7 @@
 
 import json  # noqa
 import sys
-import time
+import timeit
 
 py3k = sys.version_info >= (3, 0)
 py33 = sys.version_info >= (3, 3)
@@ -141,10 +141,7 @@ except ImportError:
     else:
         import dummy_thread as thread  # noqa
 
-if win32 or jython:
-    time_func = time.clock
-else:
-    time_func = time.time
+time_func = timeit.default_timer
 
 try:
     from functools import partial


### PR DESCRIPTION
Python 3.8 has dropped the deprecated time.clock() function which makes mako fail
with an AttributeError on import on Windows.

The way time_func was defined (clock() on Windows and time() everywhere else) made it
return a high precision wall clock time without a defined reference. This is exactly
what timeit.default_timer() does for all versions of Python on all platforms,
so just use that instead.

Fixes #301