### PR TITLE
Specify extras for gettext message extractors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,12 +77,20 @@ setup(
       css+mako = mako.ext.pygmentplugin:MakoCssLexer
 
       [babel.extractors]
-      mako = mako.ext.babelplugin:extract
+      mako = mako.ext.babelplugin:extract [babel]
 
       [lingua.extractors]
-      mako = mako.ext.linguaplugin:LinguaMakoExtractor
+      mako = mako.ext.linguaplugin:LinguaMakoExtractor [lingua]
 
       [console_scripts]
       mako-render = mako.cmd:cmdline
       """,
+    extras_require={
+        'babel': [
+            'Babel',
+        ],
+        'lingua': [
+            'lingua',
+        ],
+    },
 )


### PR DESCRIPTION
Mako provides 'gettext' message extractors for 'lingua' and 'Babel'.
They are declared as 'setuptools' entry points. Such entry points can
specify a list of 'extras'. Before loading the entry points
'pkg_resources' checks that these extra dependencies are available.
If they are missing pkg_resources raises the appropriate exception
and the caller can react accordingly.

GitHub: #304