### PR TITLE
Use unittest.SkipTest (again?)

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -10,13 +10,6 @@ from mako.compat import py3k
 from mako.template import Template
 from mako.util import update_wrapper
 
-try:
-    # unitttest has a SkipTest also but pytest doesn't
-    # honor it unless nose is imported too...
-    from nose import SkipTest
-except ImportError:
-    from _pytest.runner import Skipped as SkipTest
-
 template_base = os.path.join(os.path.dirname(__file__), "templates")
 module_base = os.path.join(template_base, "modules")
 
@@ -148,7 +141,7 @@ def skip_if(predicate, reason=None):
         def maybe(*args, **kw):
             if predicate():
                 msg = "'%s' skipped: %s" % (fn_name, reason)
-                raise SkipTest(msg)
+                raise unittest.SkipTest(msg)
             else:
                 return fn(*args, **kw)
 

--- a/test/test_cache.py
+++ b/test/test_cache.py
@@ -1,4 +1,5 @@
 import time
+import unittest
 
 from mako import lookup
 from mako.cache import CacheImpl
@@ -9,7 +10,6 @@ from mako.lookup import TemplateLookup
 from mako.template import Template
 from test import eq_
 from test import module_base
-from test import SkipTest
 from test import TemplateTest
 from test.util import result_lines
 
@@ -649,9 +649,9 @@ class BeakerCacheTest(RealBackendTest, CacheTest):
 
     def setUp(self):
         if not beaker_cache.has_beaker:
-            raise SkipTest("Beaker is required for these tests.")
+            raise unittest.SkipTest("Beaker is required for these tests.")
         if not py27:
-            raise SkipTest("newer beakers not working w/ py26")
+            raise unittest.SkipTest("newer beakers not working w/ py26")
 
     def _install_mock_cache(self, template, implname=None):
         template.cache_args["manager"] = self._regions()
@@ -676,7 +676,9 @@ class DogpileCacheTest(RealBackendTest, CacheTest):
         try:
             import dogpile.cache  # noqa
         except ImportError:
-            raise SkipTest("dogpile.cache is required to run these tests")
+            raise unittest.SkipTest(
+                "dogpile.cache is required to run these tests"
+            )
 
     def _install_mock_cache(self, template, implname=None):
         template.cache_args["regions"] = self._regions()


### PR DESCRIPTION
While I can believe that the standard exception might not have worked
with some ancient version of pytest, it certainly works just fine now.
This saves people from importing nose which kills pytest
via DeprecationWarnings these days.