### PR TITLE
Fix deprecation warnings due to invalid escape sequences.

### DIFF
--- a/doc/build/conf.py
+++ b/doc/build/conf.py
@@ -252,7 +252,7 @@ latex_documents = [
 
 # Additional stuff for the LaTeX preamble.
 # sets TOC depth to 2.
-latex_preamble = "\setcounter{tocdepth}{3}"
+latex_preamble = r"\setcounter{tocdepth}{3}"
 
 # Documents to append as an appendix to all manuals.
 # latex_appendices = []


### PR DESCRIPTION
This fixes the below warning in docs conf script

```
find . -iname '*.py' | grep -v 2to3 | xargs -P4 -I{} python3.8 -Wall -m py_compile {}
./doc/build/conf.py:255: DeprecationWarning: invalid escape sequence \s
  latex_preamble = "\setcounter{tocdepth}{3}"
```