### PR TITLE
Avoid warnings under Python 3.10

### DIFF
--- a/mako/ext/linguaplugin.py
+++ b/mako/ext/linguaplugin.py
@@ -27,7 +27,15 @@ class LinguaMakoExtractor(Extractor, MessageExtractor):
         self.python_extractor = get_extractor("x.py")
         if fileobj is None:
             fileobj = open(filename, "rb")
-        return self.process_file(fileobj)
+            must_close = True
+        else:
+            must_close = False
+        try:
+            for message in self.process_file(fileobj):
+                yield message
+        finally:
+            if must_close:
+                fileobj.close()
 
     def process_python(self, code, code_lineno, translator_strings):
         source = code.getvalue().strip()

--- a/mako/template.py
+++ b/mako/template.py
@@ -12,7 +12,6 @@ import os
 import re
 import shutil
 import stat
-import sys
 import tempfile
 import types
 import weakref
@@ -414,14 +413,12 @@ class Template(object):
                     self, data, filename, path, self.module_writer
                 )
             module = compat.load_module(self.module_id, path)
-            del sys.modules[self.module_id]
             if module._magic_number != codegen.MAGIC_NUMBER:
                 data = util.read_file(filename)
                 _compile_module_file(
                     self, data, filename, path, self.module_writer
                 )
                 module = compat.load_module(self.module_id, path)
-                del sys.modules[self.module_id]
             ModuleInfo(module, path, self, filename, None, None, None)
         else:
             # template filename and no module directory, compile code

--- a/test/ext/test_babelplugin.py
+++ b/test/ext/test_babelplugin.py
@@ -63,6 +63,7 @@ class ExtractMakoTestCase(TemplateTest):
     @skip()
     def test_extract(self):
         mako_tmpl = open(os.path.join(template_base, "gettext.mako"))
+        self.addCleanup(mako_tmpl.close)
         messages = list(
             extract(
                 mako_tmpl,
@@ -103,6 +104,7 @@ class ExtractMakoTestCase(TemplateTest):
         mako_tmpl = open(
             os.path.join(template_base, "gettext_utf8.mako"), "rb"
         )
+        self.addCleanup(mako_tmpl.close)
         message = next(
             extract(mako_tmpl, set(["_", None]), [], {"encoding": "utf-8"})
         )
@@ -113,6 +115,7 @@ class ExtractMakoTestCase(TemplateTest):
         mako_tmpl = open(
             os.path.join(template_base, "gettext_cp1251.mako"), "rb"
         )
+        self.addCleanup(mako_tmpl.close)
         message = next(
             extract(mako_tmpl, set(["_", None]), [], {"encoding": "cp1251"})
         )

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import unittest
 
 from mako import compat
@@ -43,10 +44,14 @@ class UtilTest(unittest.TestCase):
     @skip_if(lambda: compat.pypy, "Pypy does this differently")
     def test_load_module(self):
         fn = os.path.join(os.path.dirname(__file__), "test_util.py")
+        sys.modules.pop("mako.template")
         module = compat.load_module("mako.template", fn)
+        self.assertNotIn("mako.template", sys.modules)
+
+        self.assertIn('UtilTest', dir(module))
         import mako.template
 
-        self.assertEqual(module, mako.template)
+        self.assertNotEqual(module, mako.template)
 
     def test_load_plugin_failure(self):
         loader = util.PluginLoader("fakegroup")


### PR DESCRIPTION
This modernizes the code to avoid `DeprecationWarning` and `ResourceWarning` encountered in the test suite under Python 3.10a4:
- [load_module](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) is deprecated
- Some files weren't being closed

This changes the semantics of the `compat.load_module` function: on Python 3.5+, the module is no longer inserted in `sys.modules`. All non-test calls did `del sys.modules[self.module_id]` right after the call, anyway. On older Python, the module is inserted and then deleted.

(Some additional `DeprecationWarning` come from Setuptools: https://github.com/pypa/setuptools/pull/2517)