### PR TITLE
Require setuptools on runtime, mako.util uses pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ v.close()
 
 readme = os.path.join(os.path.dirname(__file__), "README.rst")
 
-install_requires = ["MarkupSafe>=0.9.2"]
+install_requires = ["MarkupSafe>=0.9.2", "setuptools"]
 
 
 class UseTox(TestCommand):


### PR DESCRIPTION
The pkg_resources module is only available when setuptools is installed.