### PR TITLE
include offending line information for template encoding issues

### DIFF
--- a/doc/build/unreleased/333.rst
+++ b/doc/build/unreleased/333.rst
@@ -1,0 +1,12 @@
+.. change::
+    :tags: debugging
+    :tickets: 333
+
+    If a template is opened with incompatible encoding (such as unicode text but
+    no UTF-8 identification on PY2, or potential encoding mismatches on PY3),
+    an exception such as UnicodeDecodeError will be raised that notes the
+    offending character position - however no line is identified.
+
+    This scenario will now return a `mako.exceptions.RuntimeException` which
+    includes the exact line as debug information, alongside the original
+    exception.

--- a/mako/util.py
+++ b/mako/util.py
@@ -166,7 +166,24 @@ class FastEncodingBuffer(object):
                 self.encoding, self.errors
             )
         else:
-            return self.delim.join(self.data)
+            try:
+                return self.delim.join(self.data)
+            except:
+                # these exceptions are usually because of an encoding issue
+                # the standard exception is vague because it happens within a
+                # line but does not show the exact line.
+                try:
+                    for idx in range(0, len(self.data)):
+                        _content = self.delim.join(list(self.data)[0:idx+1])
+                    # this should never happen
+                    return _content
+                except Exception as exc:
+                    from mako import exceptions
+                    raise exceptions.RuntimeException(
+                        "Exception raised on template line %s:" % (idx),
+                        exc
+                    )
+                    raise
 
 
 class LRUCache(dict):

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -569,9 +569,14 @@ quand une drôle de petite voix m’a réveillé. Elle disait:
         template = self._file_template(
             "chs_utf8.html", output_encoding=None, disable_unicode=True
         )
-        self.assertRaises(
-            UnicodeDecodeError, template.render_unicode, name="毛泽东"
-        )
+
+        with self.assertRaises(exceptions.RuntimeException) as cm:
+           template.render_unicode(name="毛泽东")
+
+        the_exception = cm.exception
+        self.assertEqual(len(the_exception.args), 2)
+        self.assertEqual(the_exception.args[0], "Exception raised on template line 3:")
+        self.assertIsInstance(the_exception.args[1], UnicodeDecodeError)
 
         template = Template(
             "${'Alors vous imaginez ma surprise, au lever"


### PR DESCRIPTION
Initial idea to handle #333 .

This caught me when we had to backport some new templates written for staging (Py3) to production (Py2).  It should catch similar encoding issues on PY3 as well.