### PR TITLE
Use `pre-commit` as linter & Checker ✨

### DIFF
--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -9,38 +9,19 @@ on:
       - "doc/**"
 
 jobs:
-  run-test:
-    name: ${{ matrix.python-version }}-${{ matrix.os }}-${{matrix.tox-env}}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      # run this job using this matrix
-      matrix:
-        os:
-          - "ubuntu-latest"
-        python-version:
-          - "3.10"
-        tox-env:
-          - ""
-          - "-e pep8"
+  deploy:
+    runs-on: ubuntu-latest
 
-      fail-fast: false
-
-    # steps to run in each job. Some are github actions, others run shell commands
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Set up python
+      - uses: actions/checkout@v2
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
-
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade tox setuptools
-          pip list
-
-      - name: Run tests
-        run: tox ${{ matrix.tox-env }}
+          python -m pip install pre-commit
+      - name: Test Project linting
+        run: |
+          pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,39 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/python/black
-    rev: 21.9b0
-    hooks:
-    -   id: black
-
--   repo: https://github.com/sqlalchemyorg/zimports
-    rev: v0.4.1
-    hooks:
-    -   id: zimports
-
-
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v2.2.3
+      hooks:
+          - id: check-merge-conflict
+          - id: check-added-large-files
+          - id: check-ast
+          - id: check-symlinks
+          - id: trailing-whitespace
+          - id: check-json
+          - id: debug-statements
+          - id: pretty-format-json
+            args: ["--autofix", "--allow-missing-credentials"]
+    - repo: https://github.com/PyCQA/isort
+      rev: 5.6.4
+      hooks:
+          - id: isort
+            args: ["--profile", "black"]
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: "8f9b4931b9a28896fb43edccb23016a7540f5b82"
+      hooks:
+          - id: flake8
+            additional_dependencies: [flake8-print]
+            files: '\.py$'
+            exclude: docs/
+            args:
+                - --select=F403,F406,F821,T003
+    - repo: https://github.com/humitos/mirrors-autoflake
+      rev: v1.3
+      hooks:
+          - id: autoflake
+            files: '\.py$'
+            exclude: '^\..*'
+            args: ["--in-place"]
+    - repo: https://github.com/psf/black
+      rev: 19.10b0
+      hooks:
+          - id: black
+            args: ["--target-version", "py37"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
 [build-system]
 build-backend = 'setuptools.build_meta'
 requires = ['setuptools >= 47', 'wheel']
-
-[tool.black]
-line-length = 79
-target-version = ['py37']

--- a/tox.ini
+++ b/tox.ini
@@ -17,20 +17,3 @@ setenv=
     cov: COVERAGE={[testenv]cov_args}
 
 commands=pytest {env:COVERAGE:} {posargs}
-
-
-[testenv:pep8]
-basepython = python3
-deps=
-      flake8
-      flake8-import-order
-      flake8-builtins
-      flake8-docstrings
-      flake8-rst-docstrings
-      pydocstyle<4.0.0
-      # used by flake8-rst-docstrings
-      pygments
-      black==21.9b0
-commands =
-    flake8 ./mako/ ./test/ setup.py --exclude test/templates,test/foo  {posargs}
-    black --check .


### PR DESCRIPTION
Based on this issue https://github.com/sqlalchemy/mako/issues/344, I was thinking about why not use `.pre-commit` as a linter and checker.

Easy way to check code and fix any issue related to code style and code linting, about the rules I use only simple and most used rules for linting, SQLalchemy's team is free to change the rules or use another one for linting.

__Note__: This is just a simple enhancement to repository structure.