### PR TITLE
Fix matching multiline control lines in templates with CRLF line endings

### DIFF
--- a/mako/lexer.py
+++ b/mako/lexer.py
@@ -420,7 +420,7 @@ class Lexer:
 
     def match_control_line(self):
         match = self.match(
-            r"(?<=^)[\t ]*(%(?!%)|##)[\t ]*((?:(?:\\r?\n)|[^\r\n])*)"
+            r"(?<=^)[\t ]*(%(?!%)|##)[\t ]*((?:(?:\\\r?\n)|[^\r\n])*)"
             r"(?:\r?\n|\Z)",
             re.M,
         )

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -32,6 +32,26 @@ class ctx:
         pass
 
 
+class MiscTest(TemplateTest):
+    def test_crlf_linebreaks(self):
+
+        crlf = r"""
+<%
+    foo = True
+    bar = True
+%>
+% if foo and \
+     bar:
+     foo and bar
+%endif
+"""
+        crlf = crlf.replace("\n", "\r\n")
+        self._do_test(
+            Template(crlf),
+            "\r\n\r\n     foo and bar\r\n"
+        )
+
+
 class EncodingTest(TemplateTest):
     def test_escapes_html_tags(self):
         from mako.exceptions import html_error_template


### PR DESCRIPTION
A missing '\\' meant that it would actually allow

```
% if foo \r
   bar:
```

in a template file and not match if the file actually had a `\r` char