### PR TITLE
Fix importing the test suite without lingua

### DIFF
--- a/test/ext/test_linguaplugin.py
+++ b/test/ext/test_linguaplugin.py
@@ -2,7 +2,6 @@ import os
 
 import pytest
 
-from mako.ext.linguaplugin import LinguaMakoExtractor
 from mako.testing.assertions import eq_
 from mako.testing.config import config
 from mako.testing.exclusions import requires_lingua
@@ -24,6 +23,8 @@ class MakoExtractTest(TemplateTest):
         register_extractors()
 
     def test_extract(self):
+        from mako.ext.linguaplugin import LinguaMakoExtractor
+
         plugin = LinguaMakoExtractor({"comment-tags": "TRANSLATOR"})
         messages = list(
             plugin(


### PR DESCRIPTION
Defer the import of LinguaMakoExtractor in order to fix the following
test error when lingua is not available:

```
ImportError while importing test module '/tmp/mako/test/ext/test_linguaplugin.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test/ext/test_linguaplugin.py:5: in <module>
    from mako.ext.linguaplugin import LinguaMakoExtractor
mako/ext/linguaplugin.py:10: in <module>
    from lingua.extractors import Extractor
E   ModuleNotFoundError: No module named 'lingua'
```