### PR TITLE
Run mako templates as standalone executables

### DIFF
--- a/doc/build/usage.rst
+++ b/doc/build/usage.rst
@@ -332,6 +332,80 @@ which describes its general API:
             print(line, "\n")
         print("%s: %s" % (str(traceback.error.__class__.__name__), traceback.error))
 
+
+Standalone Template Evaluation
+==============================
+
+Direct Template Rendering
+-------------------------
+
+You can evaluate a template file with the ``mako-render`` tool directly.
+Alternatively, you can execute the `mako` Python package with ``python3 -m mako``.
+
+All available options can be seen by invoking:
+
+.. sourcecode:: sh
+    mako-render --help
+
+By default, the template is read from ``stdin``, and results are written to ``stdout``.
+To evaluate template files, pass the template file name, variables, and some arguments.
+
+Suppose you have this ``mytemplate.mako``:
+
+.. sourcecode:: mako
+
+    paper of the year by: ${name}!
+
+You can then evaluate the template on command-line by calling
+
+.. sourcecode:: sh
+
+    mako-render --var name="aperture science" mytemplate.mako
+
+
+Template Execution
+------------------
+
+``mako-render`` can also be used for executable template files. Such a file may
+be useful for dynamically generating static config files, especially in
+conjunction with some kind of "execfs" which executes files when they are read.
+
+Command line arguments given to the template can be evaluated within the template.
+
+To use this feature, choose ``#!/usr/bin/env -S mako-render -s -a --`` as your
+shebang. The ``-s`` will strip away the shebang (which is part of the template)
+from the resulting output. Using ``--`` allows us to pass template cli arguments
+starting with ``-``. Option ``-a`` enables passing cli arguments to the template
+as ``sys.argv`` so the template can do arg-parsing on its own easily.
+
+
+In this example, we have an executable text file named ``executabletemplate.mako``:
+
+.. sourcecode:: mako
+
+    #!/usr/bin/env -S mako-render -s -a --
+    <%!
+    import argparse
+    cli = argparse.ArgumentParser()
+    cli.add_argument("someargument")
+    cli.add_argument("--test")
+    args = cli.parse_args()
+    %>\
+    templates can be executed: ${args.test} ${args.someargument}
+
+Let's execute this template by running:
+
+.. sourcecode:: sh
+
+    ./executabletemplate.mako well! --test 'it works'
+
+This will result in output:
+
+.. sourcecode::
+
+    templates can be executed: it works well!
+
+
 Common Framework Integrations
 =============================
 

--- a/mako/__main__.py
+++ b/mako/__main__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+"""
+entry point for directly running mako as templating engine.
+
+that way, mako can directly be used as an rendering interpreter
+in an executable text files' shebang:
+#!/usr/bin/env -S python3 -m mako -s --
+"""
+
+from .cmd import cmdline
+
+if __name__ == "__main__":
+    cmdline()

--- a/test/templates/cmd_args.mako
+++ b/test/templates/cmd_args.mako
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S mako-render -s -a --
+<%
+import argparse
+cli = argparse.ArgumentParser()
+cli.add_argument("stuff")
+cli.add_argument("--test")
+args = cli.parse_args()
+%>\
+executable template ${args.stuff} ${args.test}

--- a/test/templates/cmd_shebang.mako
+++ b/test/templates/cmd_shebang.mako
@@ -1,0 +1,2 @@
+#!/usr/bin/env -S mako-render -s
+executable template ${x}

--- a/test/test_cmd.py
+++ b/test/test_cmd.py
@@ -95,3 +95,34 @@ class CmdTest(TemplateTest):
             SystemExit, "error: can't find fake.lalala"
         ):
             cmdline(["--var", "x=5", "fake.lalala"])
+
+    def test_strip_shebang(self):
+        with self._capture_output_fixture() as stdout:
+            cmdline(
+                [
+                    "--var",
+                    "x=42",
+                    "--strip-shebang",
+                    os.path.join(config.template_base,
+                                 "cmd_shebang.mako"),
+                ]
+            )
+
+        eq_(stdout.write.mock_calls[0][1][0], "executable template 42")
+
+    def test_template_arguments(self):
+        with self._capture_output_fixture() as stdout:
+            cmdline(
+                [
+                    "-s",  # short form for shebang strip
+                    "-a",  # replace sys.argv during rendering
+                    os.path.join(config.template_base,
+                                 "cmd_args.mako"),
+                    "--",
+                    "--test=42",
+                    "with args",
+                ]
+            )
+
+        eq_(stdout.write.mock_calls[0][1][0],
+            "executable template with args 42")


### PR DESCRIPTION
That way, mako can directly evaluate template files and can be used as a file interpreter.
    
When using either
* `#!/usr/bin/env -S python3 -m mako -s -a --`
* `#!/usr/bin/env -S mako-render -s -a --` as shebang, a file can be templated directly, and behaves similar to a PHP script.
With this commit, Python can be run as PyHP :)

This is possible because `-s` or `--strip-shebang` strips away the shebang line in the input template.
Program arguments get modified so you can even run `./awesome.mako --my-argument test --rolf`

`-a` shifts the template argv - the `sys.argv` is replaced by the cmdline args to the template execution.
It can then use regular `argparse` for parsing further arguments.

One can use this new feature to dynamically generate static config files, for example.
Or generate arbitary files when using something like `execfs`.

So this could be a simple example for an executable `test.mako` file:
```mako
#!/usr/bin/mako-render -s --
This is awesome!
<%
# hehe like pyhp :)
import argparse
cli = argparse.ArgumentParser()
cli.add_argument("stuff")
# argparsing also works as expected for an executable:
args = cli.parse_args()
%>
stuff: ${args.stuff}
```

run as
``` bash
$ ./test.mako yay
This is awesome!

stuff: yay
```