### PR TITLE
Restore unit tests in classes starting with Test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,7 +75,7 @@ tag_build = dev
 [tool:pytest]
 addopts= --tb native -v -r fxX -p warnings
 python_files=test/*test_*.py
-python_classes=*Test
+python_classes=*Test Test*
 filterwarnings =
     error::DeprecationWarning:test
     error::DeprecationWarning:mako

--- a/test/test_loop.py
+++ b/test/test_loop.py
@@ -1,4 +1,5 @@
 import re
+import unittest
 
 from mako import exceptions
 from mako.codegen import _FOR_LOOP
@@ -11,7 +12,7 @@ from mako.testing.fixtures import TemplateTest
 from mako.testing.helpers import flatten_result
 
 
-class TestLoop:
+class TestLoop(unittest.TestCase):
     def test__FOR_LOOP(self):
         for statement, target_list, expression_list in (
             ("for x in y:", "x", "y"),
@@ -136,7 +137,7 @@ ${x} ${loop.index} <- outer loop
         )
 
 
-class TestLoopStack:
+class TestLoopStack(unittest.TestCase):
     def setUp(self):
         self.stack = LoopStack()
         self.bottom = "spam"
@@ -179,7 +180,7 @@ class TestLoopStack:
         assert before == (after + 1), "Exiting a context pops the stack"
 
 
-class TestLoopContext:
+class TestLoopContext(unittest.TestCase):
     def setUp(self):
         self.iterable = [1, 2, 3]
         self.ctx = LoopContext(self.iterable)


### PR DESCRIPTION
https://github.com/sqlalchemy/mako/commit/7e52b60b7dac75a3c7177e69244123c0dad9e9d9 changed tests from `unittest.TestCase` to pytest collection.  But since then only classes *ending* in the word `Test` were considered to be tests; classes *starting* in `Test` were not.  This disabled some existing tests, and while renaming these would be a viable way to restore coverage, extending the list of test class names avoids accidentally missing similar classes in the future.

The loop test classes make use of the `setUp` method, so in their current form they need to inherit from `unittest` again.  Changing to pytest fixtures would be a possible future modification.

This commit adds 33 tests that had been missing before:
* 25 methods in 4 classes from `test_loop.py`
* 2 methods in `TestTemplateAPI` from `test_template.py`
* 6 methods in `TestTGPlugin` from `test_tgplugin.py`