### PR TITLE
Encode output inside mako cmd and write as binary

### DIFF
--- a/mako/cmd.py
+++ b/mako/cmd.py
@@ -91,7 +91,11 @@ def cmdline(argv=None):
         _exit()
     else:
         if output_file:
-            open(output_file, "wt", encoding=output_encoding).write(rendered)
+            if output_encoding is None:
+                encoded_output = rendered.encode()
+            else:
+                encoded_output = rendered.encode(output_encoding)
+            open(output_file, "wb").write(encoded_output)
         else:
             sys.stdout.write(rendered)
 


### PR DESCRIPTION
This change is a proposed fix for #376 