### PR TITLE
Add support for Python 3.11 and 3.12 and drop EOL 3.7

### DIFF
--- a/.github/workflows/run-on-pr.yaml
+++ b/.github/workflows/run-on-pr.yaml
@@ -28,10 +28,10 @@ jobs:
     # steps to run in each job. Some are github actions, others run shell commands
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           architecture: ${{ matrix.architecture }}

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -23,7 +23,6 @@ jobs:
           - "windows-latest"
           - "macos-latest"
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -27,6 +27,8 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
 
         exclude:
           # beaker raises warning on 3.10. only windows seems affected
@@ -39,12 +41,13 @@ jobs:
     # steps to run in each job. Some are github actions, others run shell commands
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           architecture: ${{ matrix.architecture }}
 
       - name: Install dependencies

--- a/mako/compat.py
+++ b/mako/compat.py
@@ -5,13 +5,13 @@
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 
 import collections
+from importlib import metadata as importlib_metadata
 from importlib import util
 import inspect
 import sys
 
 win32 = sys.platform.startswith("win")
 pypy = hasattr(sys, "pypy_version_info")
-py38 = sys.version_info >= (3, 8)
 
 ArgSpec = collections.namedtuple(
     "ArgSpec", ["args", "varargs", "keywords", "defaults"]
@@ -60,12 +60,6 @@ def exception_as():
 
 def exception_name(exc):
     return exc.__class__.__name__
-
-
-if py38:
-    from importlib import metadata as importlib_metadata
-else:
-    import importlib_metadata  # noqa
 
 
 def importlib_metadata_get(group):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ requires = ['setuptools >= 47', 'wheel']
 
 [tool.black]
 line-length = 79
-target-version = ['py37']
+target-version = ['py38']

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Intended Audience :: Developers
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -31,12 +30,11 @@ project_urls =
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 zip_safe = false
 
 install_requires =
     MarkupSafe >= 0.9.2
-    importlib-metadata;python_version<"3.8"
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Internet :: WWW/HTTP :: Dynamic Content


### PR DESCRIPTION
The [second Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

Python 3.12.0 final is due out in two weeks: [2023-10-02](https://peps.python.org/pep-0693/).

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/
