### PR TITLE
fix percent escape not working when not at the beginning of the line

### DIFF
--- a/mako/lexer.py
+++ b/mako/lexer.py
@@ -357,11 +357,11 @@ class Lexer:
             r"""
                 (.*?)         # anything, followed by:
                 (
-                 ((?<=\n)|^)(?=[ \t]*(?=%|\#\#)) # an eval or line-based
-                                             # comment preceded by a
-                                             # consumed newline and whitespace
+                 (?<=\n)(?=[ \t]*(?=%(?!%)|\#\#))   # an eval or line-based
+                                                    # comment, preceded by a
+                                                    # consumed newline and whitespace
                  |
-                 (?<!%)(?=%%+)
+                 (?<!%)(?=%%+)  # consume the first percent sign out of a group of percent signs
                  |
                  (?=\${)      # an expression
                  |

--- a/mako/lexer.py
+++ b/mako/lexer.py
@@ -357,9 +357,11 @@ class Lexer:
             r"""
                 (.*?)         # anything, followed by:
                 (
-                 (?<=\n)(?=[ \t]*(?=%|\#\#)) # an eval or line-based
+                 ((?<=\n)|^)(?=[ \t]*(?=%|\#\#)) # an eval or line-based
                                              # comment preceded by a
                                              # consumed newline and whitespace
+                 |
+                 (?<!%)(?=%%+)
                  |
                  (?=\${)      # an expression
                  |

--- a/mako/lexer.py
+++ b/mako/lexer.py
@@ -357,11 +357,12 @@ class Lexer:
             r"""
                 (.*?)         # anything, followed by:
                 (
-                 (?<=\n)(?=[ \t]*(?=%(?!%)|\#\#))   # an eval or line-based
-                                                    # comment, preceded by a
-                                                    # consumed newline and whitespace
+                 (?<=\n)(?=[ \t]*(?=%(?!%)|\#\#))  # an eval or line-based
+                                            # comment, preceded by a
+                                            # consumed newline and whitespace
                  |
-                 (?<!%)(?=%%+)  # consume the first percent sign out of a group of percent signs
+                 (?<!%)(?=%%+) # consume the first percent sign
+                               # out of a group of percent signs
                  |
                  (?=\${)      # an expression
                  |

--- a/mako/lexer.py
+++ b/mako/lexer.py
@@ -247,6 +247,8 @@ class Lexer:
                 continue
             if self.match_python_block():
                 continue
+            if self.match_percent():
+                continue
             if self.match_text():
                 continue
 
@@ -352,17 +354,24 @@ class Lexer:
         else:
             return True
 
+    def match_percent(self):
+        match = self.match(r"(?<=^)(\s*)%%(%*)", re.M)
+        if match:
+            self.append_node(
+                parsetree.Text, match.group(1) + "%" + match.group(2)
+            )
+            return True
+        else:
+            return False
+
     def match_text(self):
         match = self.match(
             r"""
                 (.*?)         # anything, followed by:
                 (
-                 (?<=\n)(?=[ \t]*(?=%(?!%)|\#\#))  # an eval or line-based
+                 (?<=\n)(?=[ \t]*(?=%|\#\#))  # an eval or line-based
                                             # comment, preceded by a
                                             # consumed newline and whitespace
-                 |
-                 (?<!%)(?=%%+) # consume the first percent sign
-                               # out of a group of percent signs
                  |
                  (?=\${)      # an expression
                  |

--- a/mako/testing/helpers.py
+++ b/mako/testing/helpers.py
@@ -18,6 +18,13 @@ def result_lines(result):
         if x.strip() != ""
     ]
 
+def result_raw_lines(result):
+    return [
+        x
+        for x in re.split(r"\r?\n", result)
+        if x.strip() != ""
+    ]
+
 
 def make_path(
     filespec: Union[Path, str],

--- a/mako/testing/helpers.py
+++ b/mako/testing/helpers.py
@@ -18,12 +18,9 @@ def result_lines(result):
         if x.strip() != ""
     ]
 
+
 def result_raw_lines(result):
-    return [
-        x
-        for x in re.split(r"\r?\n", result)
-        if x.strip() != ""
-    ]
+    return [x for x in re.split(r"\r?\n", result) if x.strip() != ""]
 
 
 def make_path(

--- a/test/test_lexer.py
+++ b/test/test_lexer.py
@@ -201,8 +201,7 @@ class LexerTest(TemplateTest):
                 {},
                 [
                     Text("""\n\n""", (1, 1)),
-                    Text("""% some whatever.\n\n""", (3, 2)),
-                    Text("   ", (5, 2)),
+                    Text("""% some whatever.\n\n    """, (3, 2)),
                     Text("% more some whatever\n", (5, 6)),
                     ControlLine("if", "if foo:", False, (6, 1)),
                     ControlLine("if", "endif", True, (7, 1)),
@@ -224,10 +223,31 @@ if <some condition>:
                 {},
                 [
                     Text("% do something\n", (1, 2)),
-                    Text("%% do something\nif <some condition>:\n", (2, 2)),
-                    Text("   ", (4, 2)),
+                    Text("%% do something\nif <some condition>:\n    ", (2, 2)),
                     Text("%%% do something\n        ", (4, 6)),
                 ],
+            ),
+        )
+    
+    def test_percent_escape_with_control_block(self):
+        template = """
+% for i in [1, 2, 3]:
+    %% do something ${i}
+% endfor
+"""
+        node = Lexer(template).parse()
+        self._compare(
+            node,
+            TemplateNode(
+                {},
+                [
+                    Text('\n', (1, 1)), 
+                    ControlLine('for', 'for i in [1, 2, 3]:', False, (2, 1)), 
+                    Text('    ', (3, 1)), 
+                    Text('% do something ', (3, 6)), 
+                    Expression('i', [], (3, 21)), 
+                    Text('\n', (3, 25)), 
+                    ControlLine('for', 'endfor', True, (4, 1))]
             ),
         )
 

--- a/test/test_lexer.py
+++ b/test/test_lexer.py
@@ -202,10 +202,31 @@ class LexerTest(TemplateTest):
                 [
                     Text("""\n\n""", (1, 1)),
                     Text("""% some whatever.\n\n""", (3, 2)),
-                    Text("   %% more some whatever\n", (5, 2)),
+                    Text("   ", (5, 2)),
+                    Text("% more some whatever\n", (5, 6)),
                     ControlLine("if", "if foo:", False, (6, 1)),
                     ControlLine("if", "endif", True, (7, 1)),
                     Text("        ", (8, 1)),
+                ],
+            ),
+        )
+
+    def test_percent_escape2(self):
+        template = """%% do something
+%%% do something
+if <some condition>:
+    %%%% do something
+        """
+        node = Lexer(template).parse()
+        self._compare(
+            node,
+            TemplateNode(
+                {},
+                [
+                    Text("% do something\n", (1, 2)),
+                    Text("%% do something\nif <some condition>:\n", (2, 2)),
+                    Text("   ", (4, 2)),
+                    Text("%%% do something\n        ", (4, 6)),
                 ],
             ),
         )

--- a/test/test_lexer.py
+++ b/test/test_lexer.py
@@ -223,12 +223,14 @@ if <some condition>:
                 {},
                 [
                     Text("% do something\n", (1, 2)),
-                    Text("%% do something\nif <some condition>:\n    ", (2, 2)),
+                    Text(
+                        "%% do something\nif <some condition>:\n    ", (2, 2)
+                    ),
                     Text("%%% do something\n        ", (4, 6)),
                 ],
             ),
         )
-    
+
     def test_percent_escape_with_control_block(self):
         template = """
 % for i in [1, 2, 3]:
@@ -241,13 +243,14 @@ if <some condition>:
             TemplateNode(
                 {},
                 [
-                    Text('\n', (1, 1)), 
-                    ControlLine('for', 'for i in [1, 2, 3]:', False, (2, 1)), 
-                    Text('    ', (3, 1)), 
-                    Text('% do something ', (3, 6)), 
-                    Expression('i', [], (3, 21)), 
-                    Text('\n', (3, 25)), 
-                    ControlLine('for', 'endfor', True, (4, 1))]
+                    Text("\n", (1, 1)),
+                    ControlLine("for", "for i in [1, 2, 3]:", False, (2, 1)),
+                    Text("    ", (3, 1)),
+                    Text("% do something ", (3, 6)),
+                    Expression("i", [], (3, 21)),
+                    Text("\n", (3, 25)),
+                    ControlLine("for", "endfor", True, (4, 1)),
+                ],
             ),
         )
 

--- a/test/test_lexer.py
+++ b/test/test_lexer.py
@@ -200,9 +200,10 @@ class LexerTest(TemplateTest):
             TemplateNode(
                 {},
                 [
-                    Text("""\n\n""", (1, 1)),
-                    Text("""% some whatever.\n\n    """, (3, 2)),
-                    Text("% more some whatever\n", (5, 6)),
+                    Text("\n\n%", (1, 1)),
+                    Text(" some whatever.\n\n", (3, 3)),
+                    Text("    %", (5, 1)),
+                    Text(" more some whatever\n", (5, 7)),
                     ControlLine("if", "if foo:", False, (6, 1)),
                     ControlLine("if", "endif", True, (7, 1)),
                     Text("        ", (8, 1)),
@@ -222,11 +223,12 @@ if <some condition>:
             TemplateNode(
                 {},
                 [
-                    Text("% do something\n", (1, 2)),
-                    Text(
-                        "%% do something\nif <some condition>:\n    ", (2, 2)
-                    ),
-                    Text("%%% do something\n        ", (4, 6)),
+                    Text("%", (1, 1)),
+                    Text(" do something\n", (1, 3)),
+                    Text("%%", (2, 1)),
+                    Text(" do something\nif <some condition>:\n", (2, 4)),
+                    Text("    %%%", (4, 1)),
+                    Text(" do something\n        ", (4, 9)),
                 ],
             ),
         )
@@ -245,14 +247,55 @@ if <some condition>:
                 [
                     Text("\n", (1, 1)),
                     ControlLine("for", "for i in [1, 2, 3]:", False, (2, 1)),
-                    Text("    ", (3, 1)),
-                    Text("% do something ", (3, 6)),
+                    Text("    %", (3, 1)),
+                    Text(" do something ", (3, 7)),
                     Expression("i", [], (3, 21)),
                     Text("\n", (3, 25)),
                     ControlLine("for", "endfor", True, (4, 1)),
                 ],
             ),
         )
+
+    def test_inline_percent(self):
+        template = """
+%% foo
+bar %% baz
+"""
+        node = Lexer(template).parse()
+        self._compare(
+            node,
+            TemplateNode(
+                {},
+                [Text("\n%", (1, 1)), Text(" foo\nbar %% baz\n", (2, 3))],
+            ),
+        )
+
+        def test_inline_percent_with_control_block(self):
+            template = """
+% for i in [1, 2, 3]:
+%% foo
+bar %% baz
+% endfor
+"""
+            node = Lexer(template).parse()
+            self._compare(
+                node,
+                TemplateNode(
+                    {},
+                    [
+                        Text("\n", (1, 1)),
+                        ControlLine(
+                            "for", "for i in [1, 2, 3]:", False, (2, 1)
+                        ),
+                        Text("%", (3, 1)),
+                        Text(" foo\nbar ", (3, 3)),
+                        Text("%", (3, 3)),
+                        Text("%", (3, 3)),
+                        Text(" baz\n", (4, 7)),
+                        ControlLine("for", "endfor", True, (5, 1)),
+                    ],
+                ),
+            )
 
     def test_old_multiline_comment(self):
         template = """#*"""

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -14,7 +14,7 @@ from mako.testing.assertions import eq_
 from mako.testing.config import config
 from mako.testing.fixtures import TemplateTest
 from mako.testing.helpers import flatten_result
-from mako.testing.helpers import result_lines
+from mako.testing.helpers import result_lines, result_raw_lines
 
 
 class ctx:
@@ -1672,15 +1672,29 @@ class FuturesTest(TemplateTest):
 class EscapeTest(TemplateTest):
     def test_percent_escape(self):
         t = Template(
-            """%% do something
+        """%% do something
 %%% do something
 if <some condition>:
     %%%% do something
 """
         )
-        assert result_lines(t.render()) == [
+        assert result_raw_lines(t.render()) == [
             "% do something",
             "%% do something",
             "if <some condition>:",
-            "%%% do something",
+            "    %%% do something",
+        ]
+    
+    def test_percent_escape2(self):
+        t = Template(
+        """
+% for i in [1, 2, 3]:
+    %% do something ${i}
+% endfor
+"""
+        )
+        assert result_raw_lines(t.render()) == [
+            "    % do something 1",
+            "    % do something 2",
+            "    % do something 3",
         ]

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -14,7 +14,8 @@ from mako.testing.assertions import eq_
 from mako.testing.config import config
 from mako.testing.fixtures import TemplateTest
 from mako.testing.helpers import flatten_result
-from mako.testing.helpers import result_lines, result_raw_lines
+from mako.testing.helpers import result_lines
+from mako.testing.helpers import result_raw_lines
 
 
 class ctx:
@@ -1672,7 +1673,7 @@ class FuturesTest(TemplateTest):
 class EscapeTest(TemplateTest):
     def test_percent_escape(self):
         t = Template(
-        """%% do something
+            """%% do something
 %%% do something
 if <some condition>:
     %%%% do something
@@ -1684,10 +1685,10 @@ if <some condition>:
             "if <some condition>:",
             "    %%% do something",
         ]
-    
+
     def test_percent_escape2(self):
         t = Template(
-        """
+            """
 % for i in [1, 2, 3]:
     %% do something ${i}
 % endfor

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -1699,3 +1699,21 @@ if <some condition>:
             "    % do something 2",
             "    % do something 3",
         ]
+
+    def test_inline_percent(self):
+        t = Template(
+            """
+% for i in [1, 2, 3]:
+%% foo
+bar %% baz
+% endfor
+"""
+        )
+        assert result_raw_lines(t.render()) == [
+            "% foo",
+            "bar %% baz",
+            "% foo",
+            "bar %% baz",
+            "% foo",
+            "bar %% baz",
+        ]

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -1667,3 +1667,20 @@ class FuturesTest(TemplateTest):
     def test_future_import(self):
         t = Template("${ x / y }", future_imports=["division"])
         assert result_lines(t.render(x=12, y=5)) == ["2.4"]
+
+
+class EscapeTest(TemplateTest):
+    def test_percent_escape(self):
+        t = Template(
+            """%% do something
+%%% do something
+if <some condition>:
+    %%%% do something
+"""
+        )
+        assert result_lines(t.render()) == [
+            "% do something",
+            "%% do something",
+            "if <some condition>:",
+            "%%% do something",
+        ]


### PR DESCRIPTION
Fixes: https://github.com/sqlalchemy/mako/issues/323

The `Lexer` now will generate wrong result when there is no `\n` before `%%`.

Case:
```python
from mako.template import Template


template = """%% do something
%%% do something
if <some condition>:
    %%%% do something
        """


print(Template(template).render())
```

The result before fix:
```
%% do something
%% do something
if <some condition>:
   %%%% do something
```

The result after fix:
```
% do something
%% do something
if <some condition>:
   %%% do something
```


