### PR TITLE
Support comprehensions inside functions when use strict_undefined flag.

### DIFF
--- a/doc/build/unreleased/320.rst
+++ b/doc/build/unreleased/320.rst
@@ -1,0 +1,9 @@
+.. change::
+    :tags: bug, parser
+    :tickets: 320
+    
+    Fixed unexpected syntax error in strict_undefined mode that occurred
+    when using comprehensions within a function in a Mako Python code block.
+    Now, the local variable in comprehensions won't be added to the checklist
+    when using strict_undefined mode.
+    Pull request courtesy Hai Zhu.

--- a/mako/pyparser.py
+++ b/mako/pyparser.py
@@ -90,6 +90,26 @@ class FindIdentifiers(_ast_util.NodeVisitor):
         self._add_declared(node.name)
         self._visit_function(node, False)
 
+    def visit_ListComp(self, node):
+        if self.in_function:
+            if not isinstance(node.elt, _ast.Name):
+                self.visit(node.elt)
+            for comp in node.generators:
+                self.visit(comp.iter)
+        else:
+            self.generic_visit(node)
+
+    visit_SetComp = visit_GeneratorExp = visit_ListComp
+
+    def visit_DictComp(self, node):
+        if self.in_function:
+            if not isinstance(node.key, _ast.Name):
+                self.visit(node.elt)
+            for comp in node.generators:
+                self.visit(comp.iter)
+        else:
+            self.generic_visit(node)
+
     def _expand_tuples(self, args):
         for arg in args:
             if isinstance(arg, _ast.Tuple):

--- a/test/test_ast.py
+++ b/test/test_ast.py
@@ -222,6 +222,42 @@ except (Foo, Bar) as e:
         parsed = ast.PythonCode(code, **exception_kwargs)
         eq_(parsed.undeclared_identifiers, {"x", "y", "Foo", "Bar"})
 
+    def test_locate_identifiers_18(self):
+        code = """
+def func():
+    return [i for i in range(10)]
+"""
+        parsed = ast.PythonCode(code, **exception_kwargs)
+        eq_(parsed.declared_identifiers, {"func"})
+        eq_(parsed.undeclared_identifiers, {"range"})
+
+    def test_locate_identifiers_19(self):
+        code = """
+def func():
+    return (i for i in range(10))
+"""
+        parsed = ast.PythonCode(code, **exception_kwargs)
+        eq_(parsed.declared_identifiers, {"func"})
+        eq_(parsed.undeclared_identifiers, {"range"})
+
+    def test_locate_identifiers_20(self):
+        code = """
+def func():
+    return {i for i in range(10)}
+"""
+        parsed = ast.PythonCode(code, **exception_kwargs)
+        eq_(parsed.declared_identifiers, {"func"})
+        eq_(parsed.undeclared_identifiers, {"range"})
+
+    def test_locate_identifiers_21(self):
+        code = """
+def func():
+    return {i: i**2 for i in range(10)}
+"""
+        parsed = ast.PythonCode(code, **exception_kwargs)
+        eq_(parsed.declared_identifiers, {"func"})
+        eq_(parsed.undeclared_identifiers, {"range"})
+
     def test_no_global_imports(self):
         code = """
 from foo import *

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -1718,7 +1718,7 @@ bar %% baz
             "bar %% baz",
         ]
 
-    def test_lsitcomp_in_func_strict(self):
+    def test_listcomp_in_func_strict(self):
         t = Template(
             """
 <%

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -1717,3 +1717,62 @@ bar %% baz
             "% foo",
             "bar %% baz",
         ]
+
+    def test_lsitcomp_in_func_strict(self):
+        t = Template(
+            """
+<%
+    mydict = { 'foo': 1 }
+    def getkeys(x):
+        return [ k for k in x.keys() ]
+%>
+
+${ ','.join( getkeys(mydict) ) }
+""",
+            strict_undefined=True,
+        )
+        assert result_raw_lines(t.render()) == ["foo"]
+
+    def test_setcomp_in_func_strict(self):
+        t = Template(
+            """
+<%
+    mydict = { 'foo': 1 }
+    def getkeys(x):
+        return { k for k in x.keys() }
+%>
+
+${ ','.join( getkeys(mydict) ) }
+""",
+            strict_undefined=True,
+        )
+        assert result_raw_lines(t.render()) == ["foo"]
+
+    def test_generator_in_func_strict(self):
+        t = Template(
+            """
+<%
+    mydict = { 'foo': 1 }
+    def getkeys(x):
+        return ( k for k in x.keys())
+%>
+
+${ ','.join( getkeys(mydict) ) }
+""",
+            strict_undefined=True,
+        )
+        assert result_raw_lines(t.render()) == ["foo"]
+
+    def test_dictcomp_in_func_strict(self):
+        t = Template(
+            """
+<%
+    def square():
+        return {i: i**2 for i in range(10)}
+%>
+
+${ square()[3] }
+""",
+            strict_undefined=True,
+        )
+        assert result_raw_lines(t.render()) == ["9"]


### PR DESCRIPTION
Fixes: https://github.com/sqlalchemy/mako/issues/320

Now the test code works as expected if strict_undefined is set to true:

```python
from mako.template import Template

text = """
<%
    mydict = { 'foo': 1 }

    ## Uncomment the following line to workaround the error
    ##k = None
    def getkeys(x):
        return [ k for k in x.keys() ]
%>

${ ','.join( getkeys(mydict) ) }
"""

tmpl = Template(text=text, strict_undefined=True)
out = tmpl.render()
print(out)
```

output:
```



foo

```
