### PR TITLE
Fix support comprehensions inside functions when use strict_undefined…

### DIFF
--- a/doc/build/unreleased/398.rst
+++ b/doc/build/unreleased/398.rst
@@ -1,0 +1,6 @@
+.. change::
+    :tags: bug, parser
+    :tickets: 398
+
+    Fixed the fix for ticket 320. It was trigerring an error in dictionary
+    comprehension when the key is not a simple name.

--- a/mako/pyparser.py
+++ b/mako/pyparser.py
@@ -92,8 +92,6 @@ class FindIdentifiers(_ast_util.NodeVisitor):
 
     def visit_ListComp(self, node):
         if self.in_function:
-            if not isinstance(node.elt, _ast.Name):
-                self.visit(node.elt)
             for comp in node.generators:
                 self.visit(comp.iter)
         else:
@@ -103,8 +101,6 @@ class FindIdentifiers(_ast_util.NodeVisitor):
 
     def visit_DictComp(self, node):
         if self.in_function:
-            if not isinstance(node.key, _ast.Name):
-                self.visit(node.elt)
             for comp in node.generators:
                 self.visit(comp.iter)
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,7 @@ show-source = true
 enable-extensions = G
 # E203 is due to https://github.com/PyCQA/pycodestyle/issues/373
 ignore =
-    A003,
+    A003,A005
     D,
     E203,E305,E711,E712,E721,E722,E741,
     N801,N802,N806,

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -878,6 +878,21 @@ class UndefinedVarsTest(TemplateTest):
 
         eq_(result_lines(t.render(t="T")), ["t is: T", "a,b,c"])
 
+    def test_dict_comprehensions_in_function_plus_undeclared_strict(self):
+        t = Template(
+            """
+<%
+    def foo():
+        return {s[0]: s for s in ('foo',)}
+%>
+
+${ foo()['f'] }
+""",
+            strict_undefined=True,
+        )
+
+        eq_(result_lines(t.render()), ["foo"])
+
 
 class StopRenderingTest(TemplateTest):
     def test_return_in_template(self):


### PR DESCRIPTION
… flag

Fixes: https://github.com/sqlalchemy/mako/issues/398

The element or key and value used respectively in list/set comprehension and dictionary comprehension cannot be used to declare identifiers so no need to visit them.