### PR TITLE
Passing keyword only args as positional should fail.

### DIFF
--- a/doc/build/defs.rst
+++ b/doc/build/defs.rst
@@ -73,6 +73,10 @@ value). This is in contrast to using context-level variables,
 which evaluate to ``UNDEFINED`` if you reference a name that
 does not exist.
 
+Note there is a quirk that results in a bare ``*`` being silently removed from
+a function definition.  The function then incorrectly
+allows keyword only arguments to be used as positional arguments.
+
 Calling Defs from Other Files
 -----------------------------
 

--- a/test/test_def.py
+++ b/test/test_def.py
@@ -62,6 +62,25 @@ class DefTest(TemplateTest):
             """look at all these args: one two three four 5 seven""",
         )
 
+    def test_def_py3k_args_quirk(self):
+        """Document quirk where bare * is silently removed which incorrectly
+        allows for kwonly args to be passed as positional.
+
+        See issue #405 for more information."""
+        template = Template(
+            """
+        <%def name="kwonly(a, *, b)">
+            hello kwonly: ${a} ${b} """
+            """
+        </%def>
+
+        ${kwonly('1', '2')}"""
+        )
+        eq_(
+            template.render().strip(),
+            """hello kwonly: 1 2""",
+        )
+
     def test_inter_def(self):
         """test defs calling each other"""
         template = Template(


### PR DESCRIPTION
Issue

#405 

This is a backwards incompatible change because code that was "working" will now throw an exception.

Historically related

836e5f97e84088cd3104cb3a30bf02e8a6c0a9a5