### PR TITLE
Fix undeclared variables in nested list comprehension with strict_undefined

### DIFF
--- a/doc/build/unreleased/418.rst
+++ b/doc/build/unreleased/418.rst
@@ -1,0 +1,7 @@
+.. change::
+    :tags: bug, parser
+    :tickets: 418
+
+    Fix undefined variable errors when strict_undefined is True and using
+    nested list comprehension.
+

--- a/mako/pyparser.py
+++ b/mako/pyparser.py
@@ -93,6 +93,7 @@ class FindIdentifiers(_ast_util.NodeVisitor):
     def visit_ListComp(self, node):
         if self.in_function:
             for comp in node.generators:
+                self.visit(comp.target)
                 self.visit(comp.iter)
         else:
             self.generic_visit(node)
@@ -102,6 +103,7 @@ class FindIdentifiers(_ast_util.NodeVisitor):
     def visit_DictComp(self, node):
         if self.in_function:
             for comp in node.generators:
+                self.visit(comp.target)
                 self.visit(comp.iter)
         else:
             self.generic_visit(node)

--- a/test/test_template.py
+++ b/test/test_template.py
@@ -916,6 +916,19 @@ ${ foo()['f'] }
 
         eq_(result_lines(t.render()), ["foo"])
 
+    def test_nested_list_comprehensions_in_function_plus_undeclared_strict(
+        self,
+    ):
+        t = Template(
+            """
+<%foo = lambda b : sum(f for s in b for f in s)%>\
+${ foo(([1,2],[3,4]))}
+""",
+            strict_undefined=True,
+        )
+
+        eq_(result_lines(t.render()), ["10"])
+
 
 class StopRenderingTest(TemplateTest):
     def test_return_in_template(self):


### PR DESCRIPTION
This fix the issue #418.