### PR TITLE
New feature: indenting the text in "context.write()" relative to the indentation of the entry of a python code block ("<%")

### DIFF
--- a/mako/codegen.py
+++ b/mako/codegen.py
@@ -893,6 +893,8 @@ class _GenerateRenderMethod:
 
     def visitCode(self, node):
         if not node.ismodule:
+            self.printer.writeline("context.code_block_entry_mark()")
+
             self.printer.write_indented_block(
                 node.text, starting_lineno=node.lineno
             )

--- a/mako/runtime.py
+++ b/mako/runtime.py
@@ -149,7 +149,6 @@ class Context:
         if (len(string) == 0):
             return
 
-        print(f"write({string}, {indent_relative_to_code_block_entry}, {self._code_block_entry_mark})")
         if ((indent_relative_to_code_block_entry) and (self._code_block_entry_mark is not None)):
             text_before_code_block_entry = self._buffer_stack[-1].getvalue(self._code_block_entry_mark)
             indent_len = len(text_before_code_block_entry)-(text_before_code_block_entry.rfind("\n") + 1)

--- a/mako/runtime.py
+++ b/mako/runtime.py
@@ -35,6 +35,7 @@ class Context:
         self._with_template = None
         self._outputting_as_unicode = None
         self.namespaces = {}
+        self._code_block_entry_mark = None
 
         # "capture" function which proxies to the
         # generic "capture" function
@@ -137,9 +138,27 @@ class Context:
 
         return self._data.get(key, builtins.__dict__.get(key, default))
 
-    def write(self, string):
+    def code_block_entry_mark(self):
+        """Mark the current location in the buffer."""
+        self._code_block_entry_mark = self._buffer_stack[-1].getpos()
+
+    def write(self, string, indent_relative_to_code_block_entry=False):
         """Write a string to this :class:`.Context` object's
         underlying output buffer."""
+
+        if (len(string) == 0):
+            return
+
+        print(f"write({string}, {indent_relative_to_code_block_entry}, {self._code_block_entry_mark})")
+        if ((indent_relative_to_code_block_entry) and (self._code_block_entry_mark is not None)):
+            text_before_code_block_entry = self._buffer_stack[-1].getvalue(self._code_block_entry_mark)
+            indent_len = len(text_before_code_block_entry)-(text_before_code_block_entry.rfind("\n") + 1)
+            indent = " " * indent_len
+
+            text_before_write = self._buffer_stack[-1].getvalue()
+            current_indent_len = len(text_before_write)-(text_before_write.rfind("\n") + 1)
+
+            string = (" " * max(len(indent) - current_indent_len, 0)) + string[:-1].replace("\n", "\n" + indent) + string[-1]
 
         self._buffer_stack[-1].write(string)
 
@@ -156,6 +175,7 @@ class Context:
         c._with_template = self._with_template
         c._outputting_as_unicode = self._outputting_as_unicode
         c.namespaces = self.namespaces
+        c._code_block_entry_mark = self._code_block_entry_mark
         c.caller_stack = self.caller_stack
         return c
 

--- a/mako/util.py
+++ b/mako/util.py
@@ -5,7 +5,6 @@
 # the MIT License: http://www.opensource.org/licenses/mit-license.php
 from ast import parse
 import codecs
-import collections
 import operator
 import os
 import re
@@ -143,23 +142,26 @@ class FastEncodingBuffer:
     and supports unicode data."""
 
     def __init__(self, encoding=None, errors="strict"):
-        self.data = collections.deque()
+        self.data = []
         self.encoding = encoding
         self.delim = ""
         self.errors = errors
         self.write = self.data.append
 
     def truncate(self):
-        self.data = collections.deque()
+        self.data = []
         self.write = self.data.append
 
-    def getvalue(self):
+    def getvalue(self, uptopos=None):
         if self.encoding:
-            return self.delim.join(self.data).encode(
+            return self.delim.join(self.data[:uptopos]).encode(
                 self.encoding, self.errors
             )
         else:
-            return self.delim.join(self.data)
+            return self.delim.join(self.data[:uptopos])
+
+    def getpos(self):
+        return len(self.data)
 
 
 class LRUCache(dict):

--- a/test/test_runtime.py
+++ b/test/test_runtime.py
@@ -2,6 +2,7 @@
 """
 from mako import runtime
 from mako.testing.assertions import eq_
+from mako.template import Template
 
 
 class ContextTest:
@@ -17,3 +18,79 @@ class ContextTest:
         eq_(d.kwargs, {"foo": "bar"})
 
         eq_(d._data["zig"], "zag")
+
+    def test_align_on_code_block_entry_1(self):
+        """
+        No "\n" in the text before "<%"
+        No identation is added before the first character of the written text because the text before "<%" already contains the indentation
+        Any "\n" in the written text make the text just after "\n" also indented
+        Last character in the written text is "\n" and no indentation is added after the "\n"
+        """
+        template = Template("""   <% context.write("text 1\\ntext 2\\n", True) %>""")
+
+        assert (
+            template.render()
+            ==
+"""\
+   text 1
+   text 2
+"""
+        )
+
+    def test_align_on_code_block_entry_2(self):
+        """
+        "\n" just before "<%"
+        No identation is added before the first character of the written text because the text before "<%" already contains the indentation
+        Any "\n" in the written text make the text just after "\n" also indented
+        Last character in the written text is not "\n"
+        """
+        template = Template("""---\n<% context.write("text 1\\ntext 2", True) %>""")
+
+        assert (
+            template.render()
+            ==
+"""\
+---
+text 1
+text 2\
+"""
+        )
+
+    def test_align_on_code_block_entry_3(self):
+        """
+        Any characters except "\n" before "<%" are part of the indentation to be taken into account while indenting the written text
+        The indentation of "<%" that is taken into account is the indentation in the generated text, not in the template
+        Any text written before the next writing with indentation is taken into account for the indentation of this next writing with indentation.
+        If this text is longer than the block indentation, then no indentation occurs for the first character of the next writing with indentation.
+        """
+        template = Template(
+"""
+Hel\\
+lo <%
+    context.write("text 1\\ntext 2\\n", True)
+    context.write("012")
+    context.write("text 3\\n", True)
+%>\\
+Good ${what} to you <%
+    context.write("\\ntext 4\\ntext 5", True)
+    context.write("6789")
+    context.write("text 6\\ntext 7\\n", True)
+%>\\
+Bye
+"""
+        )
+
+        assert (
+            template.render(what="day")
+            ==
+"""
+Hello text 1
+      text 2
+012   text 3
+Good day to you 
+                text 4
+                text 56789text 6
+                text 7
+Bye
+"""
+        )

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -36,6 +36,15 @@ class UtilTest:
         buf.write(s[10:])
         eq_(buf.getvalue(), s.encode("utf-8"))
 
+    def test_fast_buffer_get_partial_value(self):
+        buf = util.FastEncodingBuffer()
+        buf.write("string a ")
+        buf.write("string b ")
+        pos = buf.getpos()
+        buf.write("string c ")
+        buf.write("string d")
+        eq_(buf.getvalue(pos), "string a string b ")
+
     def test_read_file(self):
         fn = os.path.join(os.path.dirname(__file__), "test_util.py")
         data = util.read_file(fn, "rb")


### PR DESCRIPTION
I implemented this feature differently from the code you proposed.
The main goal was to be able to retrieve for any "context.write()" in a code block the indentation of "<%". To achieve that, I added a new action in "codegen" which is to get the current position of the last element in the buffer "data" in the current "FastEncodingBuffer". I think that this operation is simple enough to not have an impact on the global performance of the tool even if this new feature is not used.

I tried to minimize the modifications of "FastEncodingBuffer" so I just added a method to get the length of data and I added a parameter of "getvalue()" to be able to use this position while concatenating the strings.
Due to this choice, each time "context.write()" is called with the new parameter equal to True, this concatenation on almost the full content of data will happen twice.
I did some performance tests on different strategies to search for the last "\n" in data and the concatenation can be from 2 times to 14 times slower than doing a search loop on data. If you think that the gain of performance is worth implementing a new method in "FastEncodingBuffer" (I was thinking about something like "get_text_since_last_cr(self, pos=None)" which will return a string without "\n" starting from the end of "data" or from "data[pos-1]") and that this new method makes sense in "FastEncodingBuffer", then I can do an update.

Regarding the added tests, do you see any additional tests that I should implement ?

And regarding the non-regression tests, do you want me to also run the 53 skipped tests ? How can I run them ? What do I need to install ?

Also, if I made any mistakes in the process of development on github, please let me know.

**Modifications:**

util.py::FastEncodingBuffer
- deque replaced by list (no specific deque feature used, list faster than deque, deque does not allow slicing which is used by the new feature)
- Creation of method "getpos()" to get the current location in "data"
- Update of method "getvalue()" to get either the full content of "data" or only the content of data up to the position retrieved previously by "getpos()"

codegen.py::_GenerateRenderMethod::visitCode()
- Mark the current location in the current FastEncodingBuffer

runtime.py::Context
- Creation of the method "code_block_entry_mark()" that marks the current location in the current FastEncodingBuffer
- Update of the method "write()"
  - New parameter "indent_relative_to_code_block_entry" allowing to activate the new feature
  - Implementation of the new feature

New tests added in test_util.py & test_runtime.py to cover the updates described above

466 tests passed, 53 skipped (linked to babel, lingua, Beaker, dogpile)